### PR TITLE
remove useless device=dri

### DIFF
--- a/org.freedesktop.dabrain34.GstPipelineStudio.json
+++ b/org.freedesktop.dabrain34.GstPipelineStudio.json
@@ -10,7 +10,7 @@
   "finish-args": [
     "--socket=fallback-x11",
     "--socket=wayland",
-    "--device=dri",
+    "--device=shm",
     "--device=all",
     "--share=ipc",
     "--share=network",


### PR DESCRIPTION
As device=all is used, no need to have device=dri