### PR TITLE
flatpak: update to GNOME 49 runtime and optimize build

### DIFF
--- a/org.freedesktop.dabrain34.GstPipelineStudio.json
+++ b/org.freedesktop.dabrain34.GstPipelineStudio.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.freedesktop.dabrain34.GstPipelineStudio",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "47",
+  "runtime-version": "49",
   "sdk": "org.gnome.Sdk",
   "sdk-extensions": [
     "org.freedesktop.Sdk.Extension.rust-stable"
@@ -15,31 +15,19 @@
     "--share=ipc",
     "--share=network",
     "--filesystem=home",
-    "--env=G_MESSAGES_DEBUG=none",
-    "--env=RUST_BACKTRACE=1"
+    "--env=G_MESSAGES_DEBUG=none"
+  ],
+  "cleanup": [
+    "/include",
+    "/lib/pkgconfig",
+    "*.la",
+    "*.a"
   ],
   "build-options": {
-    "append-path": "/usr/lib/sdk/rust-stable/bin"
+    "append-path": "/usr/lib/sdk/rust-stable/bin",
+    "strip": true
   },
   "modules": [
-    {
-      "name": "gstreamer",
-      "buildsystem": "meson",
-      "builddir": true,
-      "config-opts": [
-        "-Ddoc=disabled",
-        "-Ddevtools=disabled"
-      ],
-      "sources": [
-        {
-          "type": "git",
-          "tag": "1.26.8",
-          "commit": "16d77e12ad213ef24e76a8cc34d347b8221c9975",
-          "url": "https://gitlab.freedesktop.org/gstreamer/gstreamer.git",
-          "disable-submodules": true
-        }
-      ]
-    },
     {
       "name": "gst-pipeline-studio",
       "buildsystem": "meson",


### PR DESCRIPTION
- Update runtime-version from 47 (EOL) to 49
- Remove GStreamer module (use runtime's bundled 1.26)
- Add cleanup rules for dev files
- Enable binary stripping for smaller size
- Remove debug RUST_BACKTRACE env variable